### PR TITLE
Add TOTP functionality

### DIFF
--- a/Comet/Server.php
+++ b/Comet/Server.php
@@ -36,6 +36,13 @@ class Server {
 	 */
 	protected $password = '';
 
+    /**
+	 * The TOTP code for administrative API requests to the Comet Server
+	 *
+	 * @var string
+	 */
+    protected $TOTPCode = '';
+
 	/**
 	 * The GuzzleHttp client used to make synchronous network requests
 	 *
@@ -77,6 +84,16 @@ class Server {
 	public function setClient(\GuzzleHttp\Client $client) {
 		$this->client = $client;
 	}
+
+    /**
+	 * Supply a TOTP code to authenticate 2FA-restricted accounts
+	 *
+	 * @param string $TOTPCode
+	 * @return void
+	 */
+	public function setTOTPCode($TOTPCode) {
+		$this->TOTPCode = $TOTPCode;
+    }
 
 	/** 
 	 * Retrieve properties about the current admin account
@@ -2186,12 +2203,16 @@ class Server {
 	 * @param NetworkRequest $nr
 	 * @return \Psr\Http\Message\RequestInterface
 	 */
-	public function AsPSR7(NetworkRequest $nr) {
+	public function AsPSR7(NetworkRequest $nr, $TOTPCode = '') {
 
 		$params = $nr->Parameters();
 		$params['Username'] = $this->username;
 		$params['AuthType'] = 'Password';
-		$params['Password'] = $this->password;
+        $params['Password'] = $this->password;
+        if((strlen($TOTPCode) > 0) || (strlen($this->TOTPCode) > 0)) {
+            $params['AuthType'] = 'PasswordTOTP';
+            $params['TOTP'] = (strlen($TOTPCode) > 0 ? $TOTPCode : $this->TOTPCode);
+        }
 
 		return new \GuzzleHttp\Psr7\Request(
 			$nr->Method(),


### PR DESCRIPTION
Added basic TOTP capabilities by altering the Network Request parameters to include `'TOTP'` if provided. Below is an example of how to authenticate with TOTP with the proposed changes:

```
// ---- With TOTP ----
<?php
require 'vendor/autoload.php'; // Load Composer classes

$server = new \Comet\Server("http://127.0.0.1:8060/", "admin", "admin");
$server->setTOTPCode("123456"); // <-- Can be computed with other PHP libraries
$accounts = $server->AdminListUsers();
var_dump($accounts);
```

The obvious trade-off with the above method is the need for an additional function call before submitting requests. However, it may be reasonably assumed that an automated script will run fast enough to only require setting the TOTP once, though this is not always the case. I did consider attempting to implement a TOTP calculator; the TOTP secret could then be defined in the constructor and computed at the time of each request and remove the need for the `setTOTPCode()` function. However, I deemed such an endeavor to go beyond the scope of the SDK.